### PR TITLE
Disable repeat mode when calling stop in a loop

### DIFF
--- a/commands/stop.js
+++ b/commands/stop.js
@@ -10,6 +10,7 @@ exports.run = async (client, message, args) => {
     if(!client.player.isPlaying(message.guild.id)) return message.channel.send(`No music playing on this server ${emotes.error}`);
 
     //Stop player
+    client.player.setRepeatMode(message.guild.id, false);
     client.player.stop(message.guild.id);
 
     //Message


### PR DESCRIPTION
This commit adds a setRepeatMode(guild_id, false) call to the code for the stop command so the music doesn't restart if the bot is in loop mode (see issue #24).