### PR TITLE
Add instruction to install ffmpeg to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ Emojis are already defined by default but you can modify them if you wish.
 
 In the console, type `npm install` to install all dependencies.
 
+For this bot to work, `ffmpeg` needs to be installed. You can download it [here](https://ffmpeg.org/download.html).
+If you are using Ubuntu you can simply run `sudo apt install ffmpeg`.
+
 To start the bot :
 
 ```


### PR DESCRIPTION
While looking through open issues of this project I noticed that #43 (and probably also #41 and #42) could be resolved by adding instructions to install ffmpeg to the README. I linked the download page for ffmpeg and added instructions for installing ffmpeg on Ubuntu (which most Linux users will probably use).