### PR TITLE
✨ move prefix tag from each command to help handler

### DIFF
--- a/commands/core/help.js
+++ b/commands/core/help.js
@@ -2,7 +2,7 @@ module.exports = {
     name: 'help',
     aliases: ['h'],
     category: 'Core',
-    utilisation: '{prefix}help <command name>',
+    utilisation: 'help <command name>',
 
     execute(client, message, args) {
         if (!args[0]) {
@@ -37,7 +37,7 @@ module.exports = {
                         { name: 'Name', value: command.name, inline: true },
                         { name: 'Category', value: command.category, inline: true },
                         { name: 'Aliase(s)', value: command.aliases.length < 1 ? 'None' : command.aliases.join(', '), inline: true },
-                        { name: 'Utilisation', value: command.utilisation.replace('{prefix}', client.config.discord.prefix), inline: true },
+                        { name: 'Utilisation', value: `${client.config.discord.prefix} ${command.utilisation}`, inline: true },
                     ],
                     timestamp: new Date(),
                     description: 'Find information on the command provided.\nMandatory arguments `[]`, optional arguments `<>`.',

--- a/commands/core/help.js
+++ b/commands/core/help.js
@@ -37,7 +37,7 @@ module.exports = {
                         { name: 'Name', value: command.name, inline: true },
                         { name: 'Category', value: command.category, inline: true },
                         { name: 'Aliase(s)', value: command.aliases.length < 1 ? 'None' : command.aliases.join(', '), inline: true },
-                        { name: 'Utilisation', value: `${client.config.discord.prefix} ${command.utilisation}`, inline: true },
+                        { name: 'Utilisation', value: `${client.config.discord.prefix}${command.utilisation}`, inline: true },
                     ],
                     timestamp: new Date(),
                     description: 'Find information on the command provided.\nMandatory arguments `[]`, optional arguments `<>`.',

--- a/commands/infos/debug.js
+++ b/commands/infos/debug.js
@@ -2,7 +2,7 @@ module.exports = {
     name: 'debug',
     aliases: [],
     category: 'Infos',
-    utilisation: '{prefix}debug',
+    utilisation: 'debug',
 
     execute(client, message) {
         message.channel.send(`${client.emotes.success} - ${client.user.username} connected in **${client.voice.connections.size}** channels !`);

--- a/commands/infos/ping.js
+++ b/commands/infos/ping.js
@@ -2,7 +2,7 @@ module.exports = {
     name: 'ping',
     aliases: [],
     category: 'Infos',
-    utilisation: '{prefix}ping',
+    utilisation: 'ping',
 
     execute(client, message) {
         message.channel.send(`${client.emotes.success} - Ping : **${client.ws.ping}ms** !`);

--- a/commands/music/clear-queue.js
+++ b/commands/music/clear-queue.js
@@ -2,7 +2,7 @@ module.exports = {
     name: 'clear-queue',
     aliases: ['cq'],
     category: 'Music',
-    utilisation: '{prefix}clear-queue',
+    utilisation: 'clear-queue',
 
     execute(client, message) {
         if (!message.member.voice.channel) return message.channel.send(`${client.emotes.error} - You're not in a voice channel !`);

--- a/commands/music/filter.js
+++ b/commands/music/filter.js
@@ -2,7 +2,7 @@ module.exports = {
     name: 'filter',
     aliases: [],
     category: 'Music',
-    utilisation: '{prefix}filter [filter name]',
+    utilisation: 'filter [filter name]',
 
     execute(client, message, args) {
         if (!message.member.voice.channel) return message.channel.send(`${client.emotes.error} - You're not in a voice channel !`);

--- a/commands/music/loop.js
+++ b/commands/music/loop.js
@@ -2,7 +2,7 @@ module.exports = {
     name: 'loop',
     aliases: ['lp', 'repeat'],
     category: 'Music',
-    utilisation: '{prefix}loop',
+    utilisation: 'loop',
 
     execute(client, message, args) {
         if (!message.member.voice.channel) return message.channel.send(`${client.emotes.error} - You're not in a voice channel !`);

--- a/commands/music/nowplaying.js
+++ b/commands/music/nowplaying.js
@@ -2,7 +2,7 @@ module.exports = {
     name: 'nowplaying',
     aliases: ['np'],
     category: 'Music',
-    utilisation: '{prefix}nowplaying',
+    utilisation: 'nowplaying',
 
     execute(client, message) {
         if (!message.member.voice.channel) return message.channel.send(`${client.emotes.error} - You're not in a voice channel !`);

--- a/commands/music/pause.js
+++ b/commands/music/pause.js
@@ -2,7 +2,7 @@ module.exports = {
     name: 'pause',
     aliases: [],
     category: 'Music',
-    utilisation: '{prefix}pause',
+    utilisation: 'pause',
 
     execute(client, message) {
         if (!message.member.voice.channel) return message.channel.send(`${client.emotes.error} - You're not in a voice channel !`);

--- a/commands/music/play.js
+++ b/commands/music/play.js
@@ -2,7 +2,7 @@ module.exports = {
     name: 'play',
     aliases: ['p'],
     category: 'Music',
-    utilisation: '{prefix}play [name/URL]',
+    utilisation: 'play [name/URL]',
 
     execute(client, message, args) {
         if (!message.member.voice.channel) return message.channel.send(`${client.emotes.error} - You're not in a voice channel !`);

--- a/commands/music/queue.js
+++ b/commands/music/queue.js
@@ -2,7 +2,7 @@ module.exports = {
     name: 'queue',
     aliases: [],
     category: 'Music',
-    utilisation: '{prefix}queue',
+    utilisation: 'queue',
 
     execute(client, message) {
         if (!message.member.voice.channel) return message.channel.send(`${client.emotes.error} - You're not in a voice channel !`);

--- a/commands/music/resume.js
+++ b/commands/music/resume.js
@@ -2,7 +2,7 @@ module.exports = {
     name: 'resume',
     aliases: [],
     category: 'Music',
-    utilisation: '{prefix}resume',
+    utilisation: 'resume',
 
     execute(client, message) {
         if (!message.member.voice.channel) return message.channel.send(`${client.emotes.error} - You're not in a voice channel !`);

--- a/commands/music/search.js
+++ b/commands/music/search.js
@@ -2,7 +2,7 @@ module.exports = {
     name: 'search',
     aliases: ['sr'],
     category: 'Music',
-    utilisation: '{prefix}search [name/URL]',
+    utilisation: 'search [name/URL]',
 
     execute(client, message, args) {
         if (!message.member.voice.channel) return message.channel.send(`${client.emotes.error} - You're not in a voice channel !`);

--- a/commands/music/shuffle.js
+++ b/commands/music/shuffle.js
@@ -2,7 +2,7 @@ module.exports = {
     name: 'shuffle',
     aliases: ['sh'],
     category: 'Music',
-    utilisation: '{prefix}shuffle',
+    utilisation: 'shuffle',
 
     execute(client, message) {
         if (!message.member.voice.channel) return message.channel.send(`${client.emotes.error} - You're not in a voice channel !`);

--- a/commands/music/skip.js
+++ b/commands/music/skip.js
@@ -2,7 +2,7 @@ module.exports = {
     name: 'skip',
     aliases: ['sk'],
     category: 'Music',
-    utilisation: '{prefix}skip',
+    utilisation: 'skip',
 
     execute(client, message) {
         if (!message.member.voice.channel) return message.channel.send(`${client.emotes.error} - You're not in a voice channel !`);

--- a/commands/music/stop.js
+++ b/commands/music/stop.js
@@ -2,7 +2,7 @@ module.exports = {
     name: 'stop',
     aliases: ['dc'],
     category: 'Music',
-    utilisation: '{prefix}stop',
+    utilisation: 'stop',
 
     execute(client, message) {
         if (!message.member.voice.channel) return message.channel.send(`${client.emotes.error} - You're not in a voice channel !`);

--- a/commands/music/volume.js
+++ b/commands/music/volume.js
@@ -2,7 +2,7 @@ module.exports = {
     name: 'volume',
     aliases: [],
     category: 'Music',
-    utilisation: '{prefix}volume [1-100]',
+    utilisation: 'volume [1-100]',
 
     execute(client, message, args) {
         if (!message.member.voice.channel) return message.channel.send(`${client.emotes.error} - You're not in a voice channel !`);

--- a/commands/music/w-filters.js
+++ b/commands/music/w-filters.js
@@ -2,7 +2,7 @@ module.exports = {
     name: 'w-filters',
     aliases: ['filters'],
     category: 'Music',
-    utilisation: '{prefix}w-filters',
+    utilisation: 'w-filters',
 
     execute(client, message) {
         if (!message.member.voice.channel) return message.channel.send(`${client.emotes.error} - You're not in a voice channel !`);


### PR DESCRIPTION
Instead of having `{prefix}` in each utilisation part, why not just get the prefix from the config in the help handler, and just add it in front. Removes the chore of having to add {prefix} each time you add a command