### PR TITLE
Fix crashing on seek command with no args

### DIFF
--- a/commands/music/seek.js
+++ b/commands/music/seek.js
@@ -10,13 +10,16 @@ module.exports = {
         const queue = player.getQueue(message.guild.id);
 
         if (!queue || !queue.playing) return message.channel.send(`No music currently playing ${message.author}... try again ? ❌`);
+        
+        if (args.length === 0) { return message.channel.send(`No argument passed ${message.author}... Please enter the timestamp in ms ! ❌`) }
+        else {
+            const timeToMS = ms(args.join(' '));
 
-        const timeToMS = ms(args.join(' '));
+            if (timeToMS >= queue.current.durationMS) return message.channel.send(`The indicated time is higher than the total time of the current song ${message.author}... try again ? ❌\n*Try for example a valid time like **5s, 10s, 20 seconds, 1m**...*`);
 
-        if (timeToMS >= queue.current.durationMS) return message.channel.send(`The indicated time is higher than the total time of the current song ${message.author}... try again ? ❌\n*Try for example a valid time like **5s, 10s, 20 seconds, 1m**...*`);
+            await queue.seek(timeToMS);
 
-        await queue.seek(timeToMS);
-
-        message.channel.send(`Time set on the current song **${ms(timeToMS, { long: true })}** ✅`);
+            message.channel.send(`Time set on the current song **${ms(timeToMS, { long: true })}** ✅`);
+        }
     },
 };


### PR DESCRIPTION
Previously if the "seek" command was called without an argument, the bot would crash.
This commit fixes the crash by checking the length of "args"