### PR TITLE
🐛Fixed nowplaying button bug

### DIFF
--- a/src/buttons/nowplaying.js
+++ b/src/buttons/nowplaying.js
@@ -6,7 +6,7 @@ module.exports = async ({ client, inter, queue }) => {
 
     const methods = ['disabled', 'track', 'queue'];
 
-    const timestamp = track.timestamp;
+    const timestamp = track.duration;
     
     const trackDuration = timestamp.progress == 'Infinity' ? 'infinity (live)' : track.duration;
 


### PR DESCRIPTION
Replaced `track.timestamp` with `track.duration`, causing the bot to crash when clicking the button