### PR TITLE
add .env to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules/
 package-lock.json
 yarn.lock
 pnpm-lock.yaml
+
+.env


### PR DESCRIPTION
Just a simple quick fix to include `.env` into `.gitignore` to ensure that important variables containing sensitive information are not tracked by Git and are not pushed to the remote repository.

sorry about my last PR that was broken, this one should be good now